### PR TITLE
Add ReminderLog factory and tests

### DIFF
--- a/database/factories/ReminderLogFactory.php
+++ b/database/factories/ReminderLogFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\ReminderLog;
+
+/**
+ * @extends Factory<ReminderLog>
+ */
+class ReminderLogFactory extends Factory
+{
+    protected $model = ReminderLog::class;
+
+    public function definition(): array
+    {
+        return [
+            'sent_at' => $this->faker->dateTime(),
+            'status' => 'sent',
+            'error_message' => null,
+        ];
+    }
+}

--- a/tests/Feature/SendRemindersTest.php
+++ b/tests/Feature/SendRemindersTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Artisan;
+use App\Models\{User, Medication, Reminder, ReminderLog};
+
+class SendRemindersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_creates_reminder_log(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+        $user->forceFill(['phone' => '+15555555555'])->save();
+
+        $medication = Medication::create([
+            'user_id' => $user->id,
+            'name' => 'Test Med',
+            'dosage' => '1 pill',
+        ]);
+
+        $reminder = Reminder::create([
+            'medication_id' => $medication->id,
+            'time_of_day' => '00:00:00',
+            'method' => 'sms',
+            'message_template' => 'Take your med',
+            'next_run' => now()->subMinute(),
+        ]);
+
+        Artisan::call('reminders:send');
+
+        $this->assertDatabaseHas('reminder_logs', [
+            'reminder_id' => $reminder->id,
+            'status' => 'sent',
+        ]);
+    }
+
+    public function test_reminder_log_factory(): void
+    {
+        $user = User::factory()->create();
+        $medication = Medication::create([
+            'user_id' => $user->id,
+            'name' => 'Factory Med',
+        ]);
+        $reminder = Reminder::create([
+            'medication_id' => $medication->id,
+            'time_of_day' => '01:00:00',
+            'method' => 'sms',
+            'message_template' => 'Another med',
+            'next_run' => now()->addHour(),
+        ]);
+
+        $log = ReminderLog::factory()->for($reminder)->create();
+
+        $this->assertDatabaseHas('reminder_logs', [
+            'id' => $log->id,
+            'reminder_id' => $reminder->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ReminderLogFactory`
- add feature tests ensuring reminder logs are stored

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_686de78b22f0832292660185480603ee