### PR TITLE
Add user relation through medication

### DIFF
--- a/app/Console/Commands/SendReminders.php
+++ b/app/Console/Commands/SendReminders.php
@@ -8,17 +8,16 @@ class SendReminders extends Command {
     protected $description = 'Send due SMS and voice reminders';
     public function handle() {
         Reminder::where('next_run','<=',now())
-            ->with(['medication.user'])
+            ->with('user')
             ->get()
             ->each(fn($reminder) => $this->process($reminder));
     }
     protected function process($r) {
         try {
-            $r->medication->user->notify(new \App\Notifications\SendReminderNotification($r));
+            $r->user->notify(new \App\Notifications\SendReminderNotification($r));
             $r->logs()->create(['status'=>'sent','sent_at'=>now()]);
         } catch (\Exception $e) {
             $r->logs()->create(['status'=>'failed','error_message'=>$e->getMessage(),'sent_at'=>now()]);
         }
         $r->update(['next_run'=>now()->addDay()]);
-    }
-}
+    }}

--- a/app/Models/Medication.php
+++ b/app/Models/Medication.php
@@ -6,5 +6,5 @@ use Illuminate\Database\Eloquent\Model;
 class Medication extends Model {
     use HasFactory;
     protected $fillable = ['user_id','name','dosage','start_date','end_date'];
-    public function reminders() { return $this->hasMany(Reminder::class); }
-}
+    public function user() { return $this->belongsTo(User::class); }
+    public function reminders() { return $this->hasMany(Reminder::class); }}

--- a/app/Models/Reminder.php
+++ b/app/Models/Reminder.php
@@ -7,6 +7,15 @@ class Reminder extends Model {
     use HasFactory;
     protected $fillable = ['medication_id','time_of_day','method','message_template','next_run'];
     public function medication() { return $this->belongsTo(Medication::class); }
-    public function user() { return $this->medication->user; }
-    public function logs() { return $this->hasMany(ReminderLog::class); }
-}
+    public function user() {
+        return $this->hasOneThrough(
+            User::class,
+            Medication::class,
+            'id',       // medications.id
+            'id',       // users.id
+            'medication_id',
+            'user_id'
+        );
+    }
+    public function logs() { return $this->hasMany(ReminderLog::class); }}
+

--- a/tests/Unit/ReminderUserRelationTest.php
+++ b/tests/Unit/ReminderUserRelationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Medication;
+use App\Models\Reminder;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReminderUserRelationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_reminder_with_user_eager_loads_user(): void
+    {
+        $user = User::factory()->create();
+        $medication = Medication::create([
+            'user_id' => $user->id,
+            'name' => 'Test Med',
+            'dosage' => '1 pill',
+            'start_date' => now()->toDateString(),
+        ]);
+        Reminder::create([
+            'medication_id' => $medication->id,
+            'time_of_day' => '08:00:00',
+            'method' => 'sms',
+            'message_template' => 'Take meds',
+            'next_run' => now(),
+        ]);
+
+        $reminder = Reminder::with('user')->first();
+
+        $this->assertTrue($reminder->relationLoaded('user'));
+        $this->assertEquals($user->id, $reminder->user->id);
+    }
+}


### PR DESCRIPTION
## Summary
- add belongsTo relationship on Medication
- add hasOneThrough user relation on Reminder
- refactor SendReminders to use Reminder->user
- add tests for eager-loading reminder user relation

## Testing
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686de789a12c83228a02976bbcf86c92